### PR TITLE
Implement fuzzy searching into more subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rooster"
-version = "2.6.1"
+version = "2.7.0"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clipboard 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooster"
-version = "2.6.1"
+version = "2.7.0"
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/conradkdotcom/rooster"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Here's a list of existing Rooster contributors:
 - [@jaezun](https://github.com/jaezun)
 - [@maxjacobson](https://github.com/maxjacobson)
 - [@qmx](https://github.com/qmx)
+- [@yamnikov-oleg](https://github.com/yamnikov-oleg)
 - Awesome Rustaceans from the [Rust Paris meetup](http://www.meetup.com/Rust-Paris/)
 
 Thank you very much for your help!  :smiley:  :heart:

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use password;
 use safe_string::SafeString;
+use std::io::Write;
 use std::ops::Deref;
 
 // On Windows and Mac, we'll use the native solutions provided by the OS libraries
@@ -87,4 +89,28 @@ pub fn paste_keys() -> String {
 #[cfg(not(target_os = "macos"))]
 pub fn paste_keys() -> String {
     "Ctrl+V".to_string()
+}
+
+pub fn confirm_password_retrieved(show: bool, password: &password::v2::Password) {
+    if show {
+        println_ok!(
+            "Alright! Here is your password for {}: {}",
+            password.name,
+            password.password.deref()
+        );
+    } else {
+        if copy_to_clipboard(&password.password).is_err() {
+            println_ok!(
+                "Hmm, I tried to copy your new password to your clipboard, but \
+                         something went wrong. You can see it with `rooster get '{}' --show`",
+                password.name,
+            );
+        } else {
+            println_ok!(
+                "Alright! You can paste your {} password anywhere with {}.",
+                password.name,
+                paste_keys()
+            );
+        }
+    }
 }

--- a/src/commands/change.rs
+++ b/src/commands/change.rs
@@ -16,11 +16,10 @@ use getopts;
 use password;
 use rpassword::prompt_password_stderr;
 use safe_string::SafeString;
-use clip::{copy_to_clipboard, paste_keys};
+use clip;
 use ffi;
 use list;
 use std::io::Write;
-use std::ops::Deref;
 
 pub fn callback_help() {
     println!("Usage:");
@@ -80,21 +79,7 @@ pub fn callback_exec(matches: &getopts::Matches,
         1
     })?;
 
-    if matches.opt_present("show") {
-        println_ok!("Alright! Here is your new password: {}",
-                    password_as_string.deref());
-    } else if copy_to_clipboard(&password_as_string).is_ok() {
-        println_ok!("Done! I've saved your new password for \"{}\". You can \
-                     paste it anywhere with {}.",
-                    password.name,
-                    paste_keys());
-    } else {
-        println_ok!("Hmm, I tried to copy your changed password to your \
-                     clipboard, but something went wrong. Don't worry, it's \
-                     saved, and you can see it with `rooster get {} --show`",
-                    query);
-        return Err(1);
-    }
-
+    let show = matches.opt_present("show");
+    clip::confirm_password_retrieved(show, &password);
     Ok(())
 }

--- a/src/commands/change.rs
+++ b/src/commands/change.rs
@@ -27,8 +27,9 @@ pub fn callback_help() {
     println!("    rooster change -h");
     println!("    rooster change <query>");
     println!("");
-    println!("Example:");
+    println!("Examples:");
     println!("    rooster change youtube");
+    println!("    rooster change ytb");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/commands/change.rs
+++ b/src/commands/change.rs
@@ -18,13 +18,14 @@ use rpassword::prompt_password_stderr;
 use safe_string::SafeString;
 use clip::{copy_to_clipboard, paste_keys};
 use ffi;
+use list;
 use std::io::Write;
 use std::ops::Deref;
 
 pub fn callback_help() {
     println!("Usage:");
     println!("    rooster change -h");
-    println!("    rooster change <app_name>");
+    println!("    rooster change <query>");
     println!("");
     println!("Example:");
     println!("    rooster change youtube");
@@ -45,56 +46,54 @@ pub fn callback_exec(matches: &getopts::Matches,
                      -> Result<(), i32> {
     check_args(matches)?;
 
-    let app_name = matches.free[1].clone();
+    let query = &matches.free[1];
 
-    match prompt_password_stderr(format!("What password do you want for \"{}\"? ", app_name)
-                                     .as_str()) {
-        Ok(password_as_string) => {
-            let password_as_string = SafeString::new(password_as_string.clone());
+    println_stderr!("");
+    let password = list::search_and_choose_password(
+        store, query, list::WITH_NUMBERS,
+        "Which password would like to update?",
+    ).ok_or(1)?.clone();
 
-            let change_result = store.change_password(app_name.deref(),
-                                                      &|old_password: password::v2::Password| {
-                password::v2::Password {
-                    name: old_password.name.clone(),
-                    username: old_password.username.clone(),
-                    password: password_as_string.clone(),
-                    created_at: old_password.created_at,
-                    updated_at: ffi::time(),
-                }
-            });
+    println_stderr!("");
+    let password_as_string = prompt_password_stderr(
+        format!("What password do you want for \"{}\"? ", password.name).as_str(),
+    ).map_err(|err| {
+        println_err!("\nI couldn't read the app's password (reason: {:?}).", err);
+        1
+    })?;
 
-            match change_result {
-                Ok(_) => {
-                    if matches.opt_present("show") {
-                        println_ok!("Alright! Here is your new password: {}",
-                                    password_as_string.deref());
-                        return Ok(());
-                    }
+    let password_as_string = SafeString::new(password_as_string);
 
-                    if copy_to_clipboard(&password_as_string).is_err() {
-                        println_ok!("Hmm, I tried to copy your changed password to your \
-                                     clipboard, but something went wrong. Don't worry, it's \
-                                     saved, and you can see it with `rooster get {} --show`",
-                                    app_name);
-                    } else {
-                        println_ok!("Done! I've saved your new password for \"{}\". You can \
-                                     paste it anywhere with {}.",
-                                    app_name,
-                                    paste_keys());
-                    }
-
-                    Ok(())
-                }
-                Err(err) => {
-                    println_err!("Woops, I couldn't save the new password (reason: {:?}).",
-                                 err);
-                    Err(1)
-                }
-            }
+    store.change_password(
+        &password.name,
+        &|old_password: password::v2::Password| {
+        password::v2::Password {
+            name: old_password.name,
+            username: old_password.username,
+            password: password_as_string.clone(),
+            created_at: old_password.created_at,
+            updated_at: ffi::time(),
         }
-        Err(err) => {
-            println_err!("\nI couldn't read the app's password (reason: {:?}).", err);
-            Err(1)
-        }
+    }).map_err(|err| {
+        println_err!("Woops, I couldn't save the new password (reason: {:?}).", err);
+        1
+    })?;
+
+    if matches.opt_present("show") {
+        println_ok!("Alright! Here is your new password: {}",
+                    password_as_string.deref());
+    } else if copy_to_clipboard(&password_as_string).is_ok() {
+        println_ok!("Done! I've saved your new password for \"{}\". You can \
+                     paste it anywhere with {}.",
+                    password.name,
+                    paste_keys());
+    } else {
+        println_ok!("Hmm, I tried to copy your changed password to your \
+                     clipboard, but something went wrong. Don't worry, it's \
+                     saved, and you can see it with `rooster get {} --show`",
+                    query);
+        return Err(1);
     }
+
+    Ok(())
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -22,8 +22,9 @@ pub fn callback_help() {
     println!("    rooster delete -h");
     println!("    rooster delete <query>");
     println!("");
-    println!("Example:");
+    println!("Examples:");
     println!("    rooster delete youtube");
+    println!("    rooster delete ytb");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 pub fn callback_help() {
     println!("Usage:");
     println!("    rooster delete -h");
-    println!("    rooster delete <app_name> ...");
+    println!("    rooster delete <app_name>");
     println!("");
     println!("Example:");
     println!("    rooster delete youtube");
@@ -42,17 +42,17 @@ pub fn callback_exec(matches: &getopts::Matches,
 
     let mut has_error = false;
 
-    for app_name in &matches.free[1..] {
-        match store.delete_password(app_name) {
-            Ok(_) => {
-                println_ok!("Done! I've deleted the password for \"{}\".", app_name);
-            }
-            Err(err) => {
-                println_err!("Woops! I couldn't find a password for \"{}\" (error: {:?}).",
-                             app_name,
-                             err);
-                has_error = true;
-            }
+    let app_name = &matches.free[1];
+
+    match store.delete_password(app_name) {
+        Ok(_) => {
+            println_ok!("Done! I've deleted the password for \"{}\".", app_name);
+        }
+        Err(err) => {
+            println_err!("Woops! I couldn't find a password for \"{}\" (error: {:?}).",
+                         app_name,
+                         err);
+            has_error = true;
         }
     }
 

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use getopts;
+use list;
 use password;
 use std::io::Write;
 
 pub fn callback_help() {
     println!("Usage:");
     println!("    rooster delete -h");
-    println!("    rooster delete <app_name>");
+    println!("    rooster delete <query>");
     println!("");
     println!("Example:");
     println!("    rooster delete youtube");
@@ -40,21 +41,18 @@ pub fn callback_exec(matches: &getopts::Matches,
                      -> Result<(), i32> {
     check_args(matches)?;
 
-    let mut has_error = false;
+    let query = &matches.free[1];
 
-    let app_name = &matches.free[1];
+    println_stderr!("");
+    let password = list::search_and_choose_password(
+        store, query, list::WITH_NUMBERS,
+        "Which password would you like me to delete?",
+    ).ok_or(1)?.clone();
 
-    match store.delete_password(app_name) {
-        Ok(_) => {
-            println_ok!("Done! I've deleted the password for \"{}\".", app_name);
-        }
-        Err(err) => {
-            println_err!("Woops! I couldn't find a password for \"{}\" (error: {:?}).",
-                         app_name,
-                         err);
-            has_error = true;
-        }
-    }
+    // This should always unwrap successfully, since the password is guaranteed to exist.
+    store.delete_password(&password.name).unwrap();
 
-    if has_error { Err(1) } else { Ok(()) }
+    println_ok!("Done! I've deleted the password for \"{}\".", password.name);
+
+    Ok(())
 }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clip;
 use getopts;
 use password;
-use clip::{copy_to_clipboard, paste_keys};
 use list;
 use std::io::Write;
-use std::ops::Deref;
 
 pub fn callback_help() {
     println!("Usage:");
@@ -62,31 +61,7 @@ pub fn callback_exec(
         store, query, list::WITH_NUMBERS, &prompt,
     ).ok_or(1)?;
 
-    confirm_password_retrieved(show, &password);
+    clip::confirm_password_retrieved(show, &password);
 
     Ok(())
-}
-
-fn confirm_password_retrieved(show: bool, password: &password::v2::Password) {
-    if show {
-        println_ok!(
-            "Alright! Here is your password for {}: {}",
-            password.name,
-            password.password.deref()
-        );
-    } else {
-        if copy_to_clipboard(&password.password).is_err() {
-            println_ok!(
-                "Hmm, I tried to copy your new password to your clipboard, but \
-                         something went wrong. You can see it with `rooster get '{}' --show`",
-                password.name,
-            );
-        } else {
-            println_ok!(
-                "Alright! You can paste your {} password anywhere with {}.",
-                password.name,
-                paste_keys()
-            );
-        }
-    }
 }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -24,11 +24,9 @@ pub fn callback_help() {
     println!("    rooster get -h");
     println!("    rooster get <query>");
     println!("");
-    println!("Example if you want to get your Google password:");
-    println!("    rooster get google");
-    println!("    rooster get ggl # fuzzy matching works too");
-    println!("");
-    println!("If multiple passwords match your search, you will be asked to choose.")
+    println!("Examples:");
+    println!("    rooster get youtube");
+    println!("    rooster get ytb");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/commands/regenerate.rs
+++ b/src/commands/regenerate.rs
@@ -17,9 +17,8 @@ use ffi;
 use list;
 use password;
 use generate::{PasswordSpec, generate_hard_password};
-use clip::{copy_to_clipboard, paste_keys};
+use clip;
 use std::io::Write;
-use std::ops::Deref;
 
 pub fn callback_help() {
     println!("Usage:");
@@ -85,24 +84,8 @@ pub fn callback_exec(matches: &getopts::Matches,
 
     match change_result {
         Ok(_) => {
-            if matches.opt_present("show") {
-                println_ok!("Alright! Here is your new password: {}",
-                            password_as_string.deref());
-                return Ok(());
-            }
-
-            if copy_to_clipboard(&password_as_string).is_err() {
-                println_ok!("Hmm, I tried to copy your new password to your clipboard, but \
-                             something went wrong. Don't worry, it's saved, and you can see it \
-                             with `rooster get {} --show`",
-                            query);
-            } else {
-                println_ok!("Done! I've saved your new password for \"{}\". You can paste it \
-                             anywhere with {}.",
-                            password.name,
-                            paste_keys());
-            }
-
+            let show = matches.opt_present("show");
+            clip::confirm_password_retrieved(show, &password);
             Ok(())
         }
         Err(err) => {

--- a/src/commands/regenerate.rs
+++ b/src/commands/regenerate.rs
@@ -14,6 +14,7 @@
 
 use getopts;
 use ffi;
+use list;
 use password;
 use generate::{PasswordSpec, generate_hard_password};
 use clip::{copy_to_clipboard, paste_keys};
@@ -23,7 +24,7 @@ use std::ops::Deref;
 pub fn callback_help() {
     println!("Usage:");
     println!("    rooster regenerate -h");
-    println!("    rooster regenerate <app_name>");
+    println!("    rooster regenerate <query>");
     println!("");
     println!("Example:");
     println!("    rooster regenerate youtube");
@@ -44,7 +45,13 @@ pub fn callback_exec(matches: &getopts::Matches,
                      -> Result<(), i32> {
     check_args(matches)?;
 
-    let app_name = matches.free[1].clone();
+    let query = &matches.free[1];
+
+    println_stderr!("");
+    let password = list::search_and_choose_password(
+        store, query, list::WITH_NUMBERS,
+        "Which password would you like to regenerate?",
+    ).ok_or(1)?.clone();
 
     let password_spec = PasswordSpec::from_matches(matches);
 
@@ -64,7 +71,7 @@ pub fn callback_exec(matches: &getopts::Matches,
         }
     };
 
-    let change_result = store.change_password(app_name.deref(),
+    let change_result = store.change_password(&password.name,
                                               &|old_password: password::v2::Password| {
         password::v2::Password {
             name: old_password.name.clone(),
@@ -87,11 +94,11 @@ pub fn callback_exec(matches: &getopts::Matches,
                 println_ok!("Hmm, I tried to copy your new password to your clipboard, but \
                              something went wrong. Don't worry, it's saved, and you can see it \
                              with `rooster get {} --show`",
-                            app_name);
+                            query);
             } else {
                 println_ok!("Done! I've saved your new password for \"{}\". You can paste it \
                              anywhere with {}.",
-                            app_name,
+                            password.name,
                             paste_keys());
             }
 

--- a/src/commands/regenerate.rs
+++ b/src/commands/regenerate.rs
@@ -26,8 +26,9 @@ pub fn callback_help() {
     println!("    rooster regenerate -h");
     println!("    rooster regenerate <query>");
     println!("");
-    println!("Example:");
+    println!("Examples:");
     println!("    rooster regenerate youtube");
+    println!("    rooster regenerate ytb");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -23,8 +23,9 @@ pub fn callback_help() {
     println!("    rooster rename -h");
     println!("    rooster rename <query> <new_app_name>");
     println!("");
-    println!("Example:");
+    println!("Examples:");
     println!("    rooster rename youtube Dailymotion");
+    println!("    rooster rename ytb Dailymotion");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -23,8 +23,9 @@ pub fn callback_help() {
     println!("    rooster transfer -h");
     println!("    rooster transfer <app> <new_username>");
     println!("");
-    println!("Example:");
+    println!("Examples:");
     println!("    rooster transfer dailymotion new@example.com");
+    println!("    rooster transfer dm new@example.com");
 }
 
 pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {

--- a/src/list.rs
+++ b/src/list.rs
@@ -68,11 +68,18 @@ pub fn print_list_of_passwords(passwords: &Vec<&Password>, with_numbers: bool, o
 }
 
 fn request_password_index_from_stdin(passwords: &Vec<&Password>, prompt: &str) -> usize {
+    assert!(!passwords.is_empty());
+
     // Read the index from the command line and convert to a number
     let mut line = String::new();
     loop {
-        println_stderr!("{}", prompt);
-        println_stderr!("Type in number from 1 to {}", passwords.len());
+
+        if passwords.len() > 1 {
+            println_stderr!("{}", prompt);
+            println_stderr!("Type in number from 1 to {}", passwords.len());
+        } else if passwords.len() == 1 {
+            println_stderr!("If this is the password you mean, type number 1.");
+        }
 
         line.clear();
         match stdin().read_line(&mut line) {
@@ -125,10 +132,6 @@ pub fn search_and_choose_password<'a>(
         p.name.to_lowercase() == query.to_lowercase()
     }) {
         return Some(&password)
-    }
-
-    if passwords.len() == 1{
-        return Some(passwords[0]);
     }
 
     let index = choose_password_in_list(&passwords, with_numbers, prompt);

--- a/src/list.rs
+++ b/src/list.rs
@@ -127,6 +127,10 @@ pub fn search_and_choose_password<'a>(
         return Some(&password)
     }
 
+    if passwords.len() == 1{
+        return Some(passwords[0]);
+    }
+
     let index = choose_password_in_list(&passwords, with_numbers, prompt);
     Some(passwords[index])
 }

--- a/src/main-rooster.rs
+++ b/src/main-rooster.rs
@@ -526,6 +526,13 @@ fn usage(password_file: &str) {
     println!("    export                     Dump all your raw password data in JSON");
     println!("    set-master-password        Set your master password");
     println!("    uninstall                  Show instructions to uninstall Rooster");
+    println!("");
+    println!("Some commands (change, delete, regenerate, get, rename, transfer)");
+    println!("support fuzzy search of passwords:");
+    println!("    rooster get google");
+    println!("    rooster get ggl");
+    println!("");
+    println!("If multiple passwords match your search, you will be asked to choose.")
 }
 
 fn main() {


### PR DESCRIPTION
Good day! Here is my humble contribution into the project :) Below I describe some of the design decisions I made, which you might want to correct.

1. [784fd56](https://github.com/conradkdotcom/rooster/commit/784fd567af2e9eff4a19438d4cee922aae204123): Created a function for fuzzy searching named `list::search_and_choose_password`, which basically combines `PasswordStore::search_passwords` and `list::choose_password_in_list`. This function is used throughout all the subcommands.

2. [784fd56](https://github.com/conradkdotcom/rooster/commit/784fd567af2e9eff4a19438d4cee922aae204123): Changed the behaviour of `list::request_password_index_from_stdin` (which led to change in behaviour of `list::choose_password_in_list`): made it return 0-based index of selected password instead of 1-based. I thought it would more intuitive and independent of the UI representation of the passwords list :)

3. [9075715](https://github.com/conradkdotcom/rooster/commit/9075715abd06b9ab8fe99b7e60d29f8cac3a1ecb): Sometimes, when search results only contain one password, rooster asks user to "select password from 1 to 1". This commit makes rooster select the only result quietly without prompting the user.

4. [4ed9b42](https://github.com/conradkdotcom/rooster/commit/4ed9b42a82256b9536d1fdbd54bc85f4166894ff): Move help text about fuzzy searching into rooster's usage text.

5. [6b2efa3](https://github.com/conradkdotcom/rooster/commit/6b2efa3bccd39170f48a091c2143eaf8f22fd481): Moved the function you recently created: `commands::get::confirm_password_retrieved` into the `clip` module since this code was also repeated in change and regenerate commands. My choice of module might not be the best, but it's the closest one by meaning I could think of :)

Resolves #27.