### PR TITLE
Fix old password being copied into clipboard on change and regenerate commands

### DIFF
--- a/src/commands/change.rs
+++ b/src/commands/change.rs
@@ -69,7 +69,7 @@ pub fn callback_exec(
 
     let password_as_string = SafeString::new(password_as_string);
 
-    store
+    let password = store
         .change_password(&password.name, &|old_password: password::v2::Password| {
             password::v2::Password {
                 name: old_password.name,

--- a/src/commands/regenerate.rs
+++ b/src/commands/regenerate.rs
@@ -89,7 +89,7 @@ pub fn callback_exec(
         });
 
     match change_result {
-        Ok(_) => {
+        Ok(password) => {
             let show = matches.opt_present("show");
             clip::confirm_password_retrieved(show, &password);
             Ok(())

--- a/src/password/v2.rs
+++ b/src/password/v2.rs
@@ -483,10 +483,11 @@ impl PasswordStore {
         &mut self,
         app_name: &str,
         closure: &Fn(Password) -> Password,
-    ) -> Result<(), PasswordError> {
+    ) -> Result<Password, PasswordError> {
         let old_p = self.delete_password(app_name.deref())?;
-
-        self.add_password(closure(old_p))
+        let new_p = closure(old_p);
+        self.add_password(new_p.clone())?;
+        Ok(new_p)
     }
 
     pub fn change_master_password(&mut self, master_password: &str) {


### PR DESCRIPTION
My bad, I didn't pay enough attention while editing the code.