### PR TITLE
Implement import command

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -27,16 +27,28 @@ pub fn callback_help() {
     println!("    rooster import dump.json");
 }
 
-pub fn callback_exec(_matches: &getopts::Matches, store: &mut PasswordStore) -> Result<(), i32> {
+pub fn check_args(matches: &getopts::Matches) -> Result<(), i32> {
+    if matches.free.len() < 2 {
+        println_err!("Woops, seems like the file path is missing here. For help, try:");
+        println_err!("    rooster import -h");
+        return Err(1);
+    }
+
+    Ok(())
+}
+
+pub fn callback_exec(matches: &getopts::Matches, store: &mut PasswordStore) -> Result<(), i32> {
+    check_args(matches)?;
+
     let imported_pwds: Vec<Password> = {
-        let path_str = &_matches.free[1];
+        let path_str = &matches.free[1];
         let dump_file = File::open(path_str).map_err(|err|{
-            println_stderr!("Uh oh, could not open the file (reason: {:?})", err);
+            println_stderr!("Uh oh, could not open the file (reason: {})", err);
             1
         })?;
         serde_json::from_reader(&dump_file).map_err(|json_err| {
             println_stderr!(
-                "Woops, I could not decode the passwords from JSON (reason: {:?}).",
+                "Woops, I could not import the passwords from JSON (reason: {}).",
                 json_err,
             );
             1
@@ -68,9 +80,9 @@ pub fn callback_exec(_matches: &getopts::Matches, store: &mut PasswordStore) -> 
     if added == 0 {
         println_stderr!("Apparently, I could not find any new password :(");
     } else if added == 1 {
-        println_ok!("Imported {} brand new password into the store!", added);
+        println_ok!("Imported {} brand new password into the Rooster file!", added);
     } else {
-        println_ok!("Imported {} brand new passwords into the store!", added);
+        println_ok!("Imported {} brand new passwords into the Rooster file!", added);
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod delete;
 pub mod generate;
 pub mod list;
 pub mod regenerate;
+pub mod import;
 pub mod export;
 pub mod set_master_password;
 pub mod rename;

--- a/src/main-rooster.rs
+++ b/src/main-rooster.rs
@@ -108,6 +108,12 @@ static COMMANDS: &'static [Command] = &[
         callback_without_store: None,
     },
     Command {
+        name: "import",
+        callback_exec: Some(commands::import::callback_exec),
+        callback_help: commands::import::callback_help,
+        callback_without_store: None,
+    },
+    Command {
         name: "export",
         callback_exec: Some(commands::export::callback_exec),
         callback_help: commands::export::callback_help,
@@ -568,6 +574,7 @@ fn usage(password_file: &str) {
     println!("    rename                     Rename the app for a password");
     println!("    transfer                   Change the username for a password");
     println!("    list                       List all apps and usernames");
+    println!("    import                     Load all your raw password data from JSON file");
     println!("    export                     Dump all your raw password data in JSON");
     println!("    set-master-password        Set your master password");
     println!("    uninstall                  Show instructions to uninstall Rooster");


### PR DESCRIPTION
`import` is used to load passwords from JSON file created by `export` (or crafted in another way) into the storage.

Since `export` writes the JSON into stdout, I was going to make `import` read stdin, so it could be used in shell piping: `cat dump.json | rooster import`. Unfortunately, user's master password is read from stdin as well, so I had to go with importing JSON from a file<sup>1</sup>.

In case of name conflicts this command will warn the user and will prefer the version in the storage over the version in the JSON.

Afterwards it prints number of added passwords.

---

<sup>1</sup> I did some googling about that problem and found out that it's possible to prompt the user without accessing stdin. This is done by reading `/dev/tty` on Unix or `CON` file on Windows. I might do some more researching and exprimenting on this topic, and if it turns out ok, I'd like to make another pull request adding support for stdin into `import` command. This new pull request should break the interface of the command: `import` will still accept file path via arguments; but if the path was not provided, it would try to parse JSON from stdin.